### PR TITLE
feat(typescript): export AppleAuthRequestResponse type

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -435,6 +435,7 @@ declare module '@invertase/react-native-apple-authentication' {
   export const AppleAuthRealUserStatus: typeof RNAppleAuth.AppleAuthRealUserStatus;
   export const AppleAuthCredentialState: typeof RNAppleAuth.AppleAuthCredentialState;
   export const AppleAuthRequestOperation: typeof RNAppleAuth.AppleAuthRequestOperation;
+  export const AppleAuthRequestResponse: typeof RNAppleAuth.AppleAuthRequestResponse;
 
   const defaultExport: {} & RNAppleAuth.Module;
   export default defaultExport;


### PR DESCRIPTION
It's helpful to export this additional type for projects that have strict type-checking enabled.

For instance this usage:

```js
import appleAuth from from "@invertase/react-native-apple-authentication";

function logout() {
  appleAuth
    .performRequest({
      user,
      requestedOperation: AppleAuthRequestOperation.LOGOUT,
    })
    .then((response) => { // error: no explicit type
      console.log({ response });
    })
}
```

results in a typescript error in the `then` block, as we don't have a way to type the function parameter `response` without constructing it from scratch or copy/pasting from this project.