### PR TITLE
fix(ios): add missing import

### DIFF
--- a/ios/RNAppleAuthentication/RNAppleAuthUtils.h
+++ b/ios/RNAppleAuthentication/RNAppleAuthUtils.h
@@ -18,6 +18,7 @@
 #ifndef RNAppleAuthUtils_h
 #define RNAppleAuthUtils_h
 
+#import <Foundation/Foundation.h>
 
 @interface RNAppleAuthUtils : NSObject
 


### PR DESCRIPTION
Compiler error: `NSObject` is not defined. I think the reason is because of the missing import Foundation.