### PR TITLE
Add ability to disable nonce behavior

### DIFF
--- a/ios/RNAppleAuthentication/RCTConvert+ASAuthorizationAppleIDRequest.m
+++ b/ios/RNAppleAuthentication/RCTConvert+ASAuthorizationAppleIDRequest.m
@@ -41,10 +41,12 @@
     appleIdRequest.user = [requestOptions valueForKey:@"user"];
   }
 
-  if ([requestOptions valueForKey:@"nonce"] != nil) {
-    appleIdRequest.nonce = [requestOptions valueForKey:@"nonce"];
-  } else {
-    appleIdRequest.nonce = [RNAppleAuthUtils randomNonce:32];
+  if (![[requestOptions valueForKey:@"nonceEnabled"] isEqual:@(NO)]) {
+    if ([requestOptions valueForKey:@"nonce"] != nil) {
+      appleIdRequest.nonce = [requestOptions valueForKey:@"nonce"];
+    } else {
+      appleIdRequest.nonce = [RNAppleAuthUtils randomNonce:32];
+    }
   }
 
   return appleIdRequest;

--- a/ios/RNAppleAuthentication/RNAppleAuthASAuthorizationDelegates.h
+++ b/ios/RNAppleAuthentication/RNAppleAuthASAuthorizationDelegates.h
@@ -23,7 +23,7 @@
 
 @interface RNAppleAuthASAuthorizationDelegates : NSObject <ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding>
 
-@property(nonatomic, strong, nonnull) NSString *nonce;
+@property(nonatomic, strong, nullable) NSString *nonce;
 @property(nonatomic, strong, nullable) void (^completion)(NSError *, NSDictionary *);
 
 - (instancetype)initWithCompletion:(void (^)(NSError *error, NSDictionary *authorizationCredential))completion andNonce:(NSString *)nonce;

--- a/ios/RNAppleAuthentication/RNAppleAuthASAuthorizationDelegates.m
+++ b/ios/RNAppleAuthentication/RNAppleAuthASAuthorizationDelegates.m
@@ -93,7 +93,7 @@
   }
 
   return @{
-      @"nonce": _nonce,
+      @"nonce": _nonce ? _nonce : (id) [NSNull null],
       @"user": appleIdCredential.user,
       @"fullName": fullName ? fullName : (id) [NSNull null],
       @"realUserStatus": @(appleIdCredential.realUserStatus),

--- a/ios/RNAppleAuthentication/RNAppleAuthModule.m
+++ b/ios/RNAppleAuthentication/RNAppleAuthModule.m
@@ -92,9 +92,12 @@ RCT_EXPORT_METHOD(performRequest:
           appleIdRequest
       ]
   ];
-    
-  NSString *rawNonce = appleIdRequest.nonce;
-  appleIdRequest.nonce = [RNAppleAuthUtils stringBySha256HashingString:rawNonce];
+
+  NSString *rawNonce = nil;
+  if (appleIdRequest.nonce) {
+    rawNonce = appleIdRequest.nonce;
+    appleIdRequest.nonce = [RNAppleAuthUtils stringBySha256HashingString:rawNonce];
+  }
 
   __block RNAppleAuthASAuthorizationDelegates *delegates = [
       [RNAppleAuthASAuthorizationDelegates alloc]


### PR DESCRIPTION
This is useful if you use a platform like Auth0, whose [Apple token exchange flow ](https://auth0.com/docs/api/authentication#token-exchange-for-native-social)doesn't currently support nonces.

With this change, you can disable nonces like so:
```javascript
await appleAuth.performRequest({
  nonceEnabled: false,
  requestedOperation: AppleAuthRequestOperation.LOGIN,
  requestedScopes: [AppleAuthRequestScope.EMAIL, AppleAuthRequestScope.FULL_NAME],
})
```