### PR TITLE
Add width+height in style for button on example so it renders

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ function App() {
       <AppleButton
         buttonStyle={AppleButton.Style.WHITE}
         buttonType={AppleButton.Type.SIGN_IN}
+        style={{
+          width: 160,
+          height: 45,
+        }}
         onPress={() => onAppleButtonPress()}
       />
     </View>


### PR DESCRIPTION
The default example won't render the button as there are no default styles with a width and a height applied.