### PR TITLE
[Critical] Fix invalid identifiers

### DIFF
--- a/ios/RNAppleAuthentication/RNAppleAuthButtonViewManager.m
+++ b/ios/RNAppleAuthentication/RNAppleAuthButtonViewManager.m
@@ -73,7 +73,7 @@ RCT_CUSTOM_VIEW_PROPERTY(cornerRadius, NSNumber *, RNAppleAuthButtonView) {
 - (UIView *)view {
     ASAuthorizationAppleIDButtonType type = ASAuthorizationAppleIDButtonTypeDefault;
     if (@available(iOS 13.2, *)) {
-        type = ASAuthorizationAppleIDButtonTypeSignUp;
+        type = ASAuthorizationAppleIDButtonTypeSignIn;
     }
     return [[RNAppleAuthButtonView alloc] initWithAuthorizationButtonType:type authorizationButtonStyle:ASAuthorizationAppleIDButtonStyleWhite];
 }
@@ -133,7 +133,7 @@ RCT_CUSTOM_VIEW_PROPERTY(cornerRadius, NSNumber *, RNAppleAuthButtonView) {
   - (UIView *)view {
       ASAuthorizationAppleIDButtonType type = ASAuthorizationAppleIDButtonTypeDefault;
       if (@available(iOS 13.2, *)) {
-          type = ASAuthorizationAppleIDButtonTypeSignUp;
+          type = ASAuthorizationAppleIDButtonTypeSignIn;
       }
       return [[RNAppleAuthButtonView alloc] initWithAuthorizationButtonType:type authorizationButtonStyle:ASAuthorizationAppleIDButtonStyleWhiteOutline];
   }
@@ -194,7 +194,7 @@ RCT_CUSTOM_VIEW_PROPERTY(cornerRadius, NSNumber *, RNAppleAuthButtonView) {
   - (UIView *)view {
       ASAuthorizationAppleIDButtonType type = ASAuthorizationAppleIDButtonTypeDefault;
       if (@available(iOS 13.2, *)) {
-          type = ASAuthorizationAppleIDButtonTypeSignUp;
+          type = ASAuthorizationAppleIDButtonTypeSignIn;
       }
       return [[RNAppleAuthButtonView alloc] initWithAuthorizationButtonType:type authorizationButtonStyle:ASAuthorizationAppleIDButtonStyleBlack];
   }


### PR DESCRIPTION
Crash when running on iOS because of the invalid name of identifiers.

Step to reproduce:

1. `yarn add @invertase/react-native-apple-authentication`
2. `cd ios && pod install`
3. `run on Xcode`