### PR TITLE
Fix 'Invalid params found...state'

### DIFF
--- a/lib/AppleAuthModule.js
+++ b/lib/AppleAuthModule.js
@@ -88,7 +88,7 @@ export default class AppleAuthModule {
       );
     }
 
-    const { requestedScopes, requestedOperation, user, nonce, nonceEnabled, ...rest } = requestOptions;
+    const { requestedScopes, requestedOperation, user, nonce, nonceEnabled, state, ...rest } = requestOptions;
 
     if (Object.keys(rest).length) {
       throw new Error(


### PR DESCRIPTION
Currently, the method `performRequest` should allow to receive the `state` as a param but now is showing the next Error:

![Screenshot 2020-06-17 at 12 43 43](https://user-images.githubusercontent.com/4986411/84889467-3130fb80-b099-11ea-8501-3b8ed850f87e.png)

This is because `state` need to be added in the request `performRequest(...)`:

![Screenshot 2020-06-17 at 12 43 55](https://user-images.githubusercontent.com/4986411/84889475-355d1900-b099-11ea-9734-56e8d726b7ce.png)

Fix:

```javascript
const { requestedScopes, requestedOperation, user, nonce, state, nonceEnabled, ...rest } = requestOptions;
```

@mikehardy @Salakar 