### PR TITLE
Update documentation for getCredentialStateForUser

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ async function onAppleButtonPress() {
   });
 
   // get current authentication state for user
+  // /!\ This method must be tested on a real device. On the iOS simulator it always throws an error.
   const credentialState = await appleAuth.getCredentialStateForUser(appleAuthRequestResponse.user);
 
   // use credentialState response to ensure the user is authenticated
@@ -204,6 +205,15 @@ So it is recommended when logging out to just clear all data you have from a use
     <key>CFBundleAllowMixedLocalizations</key>
     <string>true</string>
     ```
+
+## Troubleshouting
+
+```
+The operation couldn’t be completed. (com.apple.AuthenticationServices.AuthorizationError error 1000.)
+```
+
+In the case you are using the function `getCredentialStateForUser` on a simulator, this error will always be fired. You should test your code on a real device.
+
 
 ## License
 

--- a/docs/interfaces/_lib_index_d_.rnappleauth.module.md
+++ b/docs/interfaces/_lib_index_d_.rnappleauth.module.md
@@ -21,7 +21,8 @@ async function onAppleButtonPress() {
     requestedScopes: [AppleAuthRequestScope.EMAIL, AppleAuthRequestScope.FULL_NAME],
   });
 
-  //authorization state request
+  // authorization state request
+  // /!\ This method must be tested on a real device. On the iOS simulator it always throws an error.
   const credentialState = await appleAuth.getCredentialStateForUser(responseObject.user);
 
   if (credentialState === AppleAuthCredentialState.AUTHORIZED) {
@@ -100,6 +101,8 @@ versions less than 13.
 _Defined in [lib/index.d.ts:381](https://github.com/invertase/react-native-apple-authentication/blob/2b75721d/lib/index.d.ts#L381)_
 
 Get the current @{RNAppleAuth.AppleAuthCredentialState} for the provided user identifier.
+
+**NOTE:** This method must be tested on a real device. On the iOS simulator it always throws an error.
 
 **Parameters:**
 


### PR DESCRIPTION
As seen in #9 and #89, the function `getCredentialStateForUser` can trigger an error on simulator, this is a normal behaviour as this function is only working on real device.
Just a small PR to specify it in the documentation