### PR TITLE
fix: moved `np` package to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/react": "16.9.38",
     "@types/react-native": "0.62.13",
     "genversion": "^2.2.1",
+    "np": "^6.2.4",
     "prettier": "^2.0.5",
     "rimraf": "^3.0.2",
     "typedoc": "^0.17.7",
@@ -45,7 +46,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "np": "^6.2.4"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
The `np` package is only needed to build the package, and should not be included in the dependencies. I noticed this when I saw a mysterious big `yarn.lock` change when I installed the package.