### PR TITLE
Add missing installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The `@invertase/react-native-apple-authentication` library will not work if you 
 
 ```bash
 yarn add @invertase/react-native-apple-authentication
+
+cd ios && pod install
 ```
 
 You will not have to manually link this module as it supports React Native auto-linking.


### PR DESCRIPTION
Adding a missing instruction since `react-native run-ios` failed to build without doing `pod install`.