### PR TITLE
Implemented isSupported check for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,17 +161,19 @@ import { View } from 'react-native';
 import { AppleButton } from '@invertase/react-native-apple-authentication';
 
 async function onAppleButtonPress() {
-
 }
 
+// Apple authentication requires API 19+, so we check before showing the login button
 function App() {
   return (
     <View>
-      <AppleButton
-        buttonStyle={AppleButton.Style.WHITE}
-        buttonType={AppleButton.Type.SIGN_IN}
-        onPress={() => onAppleButtonPress()}
-      />
+      {appleAuthAndroid.isSupported && (
+        <AppleButton
+          buttonStyle={AppleButton.Style.WHITE}
+          buttonType={AppleButton.Type.SIGN_IN}
+          onPress={() => onAppleButtonPress()}
+        />
+      )}
     </View>
   );
 }

--- a/android/src/main/java/com/RNAppleAuthentication/AppleAuthenticationAndroidModule.java
+++ b/android/src/main/java/com/RNAppleAuthentication/AppleAuthenticationAndroidModule.java
@@ -1,6 +1,7 @@
 package com.RNAppleAuthentication;
 
 import android.app.Activity;
+import android.os.Build;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -74,6 +75,7 @@ public class AppleAuthenticationAndroidModule extends ReactContextBaseJavaModule
 
         constants.put("ResponseType", ResponseType);
         constants.put("Scope", Scope);
+        constants.put("isSupported", Build.VERSION.SDK_INT >= 19);
 
         return constants;
     }

--- a/docs/interfaces/_lib_index_d_.appleauthandroid.md
+++ b/docs/interfaces/_lib_index_d_.appleauthandroid.md
@@ -20,11 +20,22 @@
 
 ## Properties
 
+###  isSupported
+
+• **isSupported**: *boolean*
+
+*Defined in [lib/index.d.ts:572](../../lib/index.d.ts#L572)*
+
+A boolean value of whether Apple Authentication is supported on this API version.
+The Apple authentication process requires API 19+ to work correctly.
+
+___
+
 ###  Error
 
 • **Error**: *[AndroidError](../modules/_lib_index_d_.md#androiderror)*
 
-*Defined in [lib/index.d.ts:579](../../lib/index.d.ts#L579)*
+*Defined in [lib/index.d.ts:586](../../lib/index.d.ts#L586)*
 
 ___
 
@@ -32,7 +43,7 @@ ___
 
 • **ResponseType**: *typeof AndroidResponseType*
 
-*Defined in [lib/index.d.ts:590](../../lib/index.d.ts#L590)*
+*Defined in [lib/index.d.ts:597](../../lib/index.d.ts#L597)*
 
 The type of response requested. Valid values are `code` and `id_token`. You can request one or both.
 
@@ -42,7 +53,7 @@ ___
 
 • **Scope**: *typeof AndroidScope*
 
-*Defined in [lib/index.d.ts:585](../../lib/index.d.ts#L585)*
+*Defined in [lib/index.d.ts:592](../../lib/index.d.ts#L592)*
 
 The amount of user information requested from Apple. Valid values are `name` and `email`.
 You can request one, both, or none.
@@ -53,7 +64,7 @@ You can request one, both, or none.
 
 ▸ **configure**(`configObject`: [AndroidConfig](_lib_index_d_.androidconfig.md)): *void*
 
-*Defined in [lib/index.d.ts:572](../../lib/index.d.ts#L572)*
+*Defined in [lib/index.d.ts:579](../../lib/index.d.ts#L579)*
 
 Prepare the module for sign in. This *must* be called before `appleAuthAndroid.signIn()`;
 
@@ -73,7 +84,7 @@ ___
 
 ▸ **signIn**(): *Promise‹[AndroidSigninResponse](_lib_index_d_.androidsigninresponse.md)›*
 
-*Defined in [lib/index.d.ts:577](../../lib/index.d.ts#L577)*
+*Defined in [lib/index.d.ts:584](../../lib/index.d.ts#L584)*
 
 Open browser window to begin user sign in. *Must* call `appleAuthAndroid.configure(options)` first.
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -196,6 +196,7 @@ dependencies {
     }
     debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
         exclude group:'com.facebook.flipper'
+        exclude group:'com.squareup.okhttp3', module:'okhttp'
     }
     debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}") {
         exclude group:'com.facebook.flipper'

--- a/example/app.android.js
+++ b/example/app.android.js
@@ -98,89 +98,97 @@ export default RootComponent = () => {
 
   return (
     <View style={[styles.container, styles.horizontal]}>
-      <Text style={styles.header}>Buttons</Text>
+      {appleAuthAndroid.isSupported && (
+        <View>
+          <Text style={styles.header}>Buttons</Text>
 
-      <Text style={{ marginBottom: 8 }}>Continue Styles</Text>
-      <AppleButton
-        style={{ marginBottom: 10 }}
-        cornerRadius={5}
-        buttonStyle={AppleButton.Style.WHITE}
-        buttonType={AppleButton.Type.CONTINUE}
-        onPress={() => doAppleLogin()}
-        leftView={(
-          <Image
-            style={{
-              alignSelf: 'center',
-              width: 14,
-              height: 14,
-              marginRight: 7,
-              resizeMode: 'contain',
-            }}
-            source={appleLogoBlack}
+          <Text style={{ marginBottom: 8 }}>Continue Styles</Text>
+          <AppleButton
+            style={{ marginBottom: 10 }}
+            cornerRadius={5}
+            buttonStyle={AppleButton.Style.WHITE}
+            buttonType={AppleButton.Type.CONTINUE}
+            onPress={() => doAppleLogin()}
+            leftView={(
+              <Image
+                style={{
+                  alignSelf: 'center',
+                  width: 14,
+                  height: 14,
+                  marginRight: 7,
+                  resizeMode: 'contain',
+                }}
+                source={appleLogoBlack}
+              />
+            )}
           />
-        )}
-      />
-      <AppleButton
-        style={{ marginBottom: 10 }}
-        cornerRadius={0}
-        buttonStyle={AppleButton.Style.WHITE_OUTLINE}
-        buttonType={AppleButton.Type.CONTINUE}
-        onPress={() => doAppleLogin()}
-        leftView={(
-          <Image
-            style={{
-              alignSelf: 'center',
-              width: 14,
-              height: 14,
-              marginRight: 7,
-              resizeMode: 'contain',
-            }}
-            source={appleLogoBlack}
+          <AppleButton
+            style={{ marginBottom: 10 }}
+            cornerRadius={0}
+            buttonStyle={AppleButton.Style.WHITE_OUTLINE}
+            buttonType={AppleButton.Type.CONTINUE}
+            onPress={() => doAppleLogin()}
+            leftView={(
+              <Image
+                style={{
+                  alignSelf: 'center',
+                  width: 14,
+                  height: 14,
+                  marginRight: 7,
+                  resizeMode: 'contain',
+                }}
+                source={appleLogoBlack}
+              />
+            )}
           />
-        )}
-      />
-      <AppleButton
-        style={{ marginBottom: 16 }}
-        cornerRadius={30}
-        buttonStyle={AppleButton.Style.BLACK}
-        buttonType={AppleButton.Type.CONTINUE}
-        onPress={() => doAppleLogin()}
-        leftView={(
-          <Image
-            style={{
-              alignSelf: 'center',
-              width: 14,
-              height: 14,
-              marginRight: 7,
-              resizeMode: 'contain',
-            }}
-            source={appleLogoWhite}
+          <AppleButton
+            style={{ marginBottom: 16 }}
+            cornerRadius={30}
+            buttonStyle={AppleButton.Style.BLACK}
+            buttonType={AppleButton.Type.CONTINUE}
+            onPress={() => doAppleLogin()}
+            leftView={(
+              <Image
+                style={{
+                  alignSelf: 'center',
+                  width: 14,
+                  height: 14,
+                  marginRight: 7,
+                  resizeMode: 'contain',
+                }}
+                source={appleLogoWhite}
+              />
+            )}
           />
-        )}
-      />
 
-      <Text style={{ marginBottom: 8 }}>Sign-in Styles</Text>
-      <AppleButton
-        style={{ marginBottom: 10 }}
-        cornerRadius={5}
-        buttonStyle={AppleButton.Style.WHITE}
-        buttonType={AppleButton.Type.SIGN_IN}
-        onPress={() => doAppleLogin()}
-      />
-      <AppleButton
-        style={{ marginBottom: 10 }}
-        cornerRadius={5}
-        buttonStyle={AppleButton.Style.WHITE_OUTLINE}
-        buttonType={AppleButton.Type.SIGN_IN}
-        onPress={() => doAppleLogin()}
-      />
-      <AppleButton
-        style={{ marginBottom: 10 }}
-        cornerRadius={5}
-        buttonStyle={AppleButton.Style.BLACK}
-        buttonType={AppleButton.Type.SIGN_IN}
-        onPress={() => doAppleLogin()}
-      />
+          <Text style={{ marginBottom: 8 }}>Sign-in Styles</Text>
+          <AppleButton
+            style={{ marginBottom: 10 }}
+            cornerRadius={5}
+            buttonStyle={AppleButton.Style.WHITE}
+            buttonType={AppleButton.Type.SIGN_IN}
+            onPress={() => doAppleLogin()}
+          />
+          <AppleButton
+            style={{ marginBottom: 10 }}
+            cornerRadius={5}
+            buttonStyle={AppleButton.Style.WHITE_OUTLINE}
+            buttonType={AppleButton.Type.SIGN_IN}
+            onPress={() => doAppleLogin()}
+          />
+          <AppleButton
+            style={{ marginBottom: 10 }}
+            cornerRadius={5}
+            buttonStyle={AppleButton.Style.BLACK}
+            buttonType={AppleButton.Type.SIGN_IN}
+            onPress={() => doAppleLogin()}
+          />
+        </View>
+      )}
+
+      {!appleAuthAndroid.isSupported && (
+        <Text>Sign In with Apple requires Android 4.4 (API 19) or higher.</Text>
+      )}
     </View>
   );
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -565,6 +565,13 @@ interface AndroidSigninResponse {
 
 interface AppleAuthAndroid {
   /**
+   * A boolean value of whether Apple Authentication is supported on this API version.
+   *
+   * The Apple authentication process requires API 19+ to work correctly.
+   */
+  isSupported: boolean;
+
+  /**
    * Prepare the module for sign in. This *must* be called before `appleAuthAndroid.signIn()`;
    *
    * @see https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_js/incorporating_sign_in_with_apple_into_other_platforms#3332113

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,6 +33,7 @@ export default appleAuth;
  * Android
  */
 export const appleAuthAndroid = RNAppleAuthModuleAndroid ? {
+  isSupported: RNAppleAuthModuleAndroid.isSupported,
   configure: RNAppleAuthModuleAndroid.configure,
   signIn: RNAppleAuthModuleAndroid.signIn,
 

--- a/type-test.tsx
+++ b/type-test.tsx
@@ -96,19 +96,21 @@ function App() {
         buttonType={AppleButton.Type.SIGN_IN}
         onPress={() => onAppleButtonPress()}
       />
-      <AppleButton
-        cornerRadius={5}
-        buttonStyle={AppleButton.Style.WHITE}
-        buttonType={AppleButton.Type.CONTINUE}
-        onPress={() => onAppleButtonPressAndroid()}
-        style={{
-          width: 200,
-        }}
-        textStyle={{
-          fontSize: 14,
-        }}
-        leftView={<View />}
-      />
+      {appleAuthAndroid.isSupported && (
+        <AppleButton
+          cornerRadius={5}
+          buttonStyle={AppleButton.Style.WHITE}
+          buttonType={AppleButton.Type.CONTINUE}
+          onPress={() => onAppleButtonPressAndroid()}
+          style={{
+            width: 200,
+          }}
+          textStyle={{
+            fontSize: 14,
+          }}
+          leftView={<View />}
+        />
+      )}
     </View>
   );
 }


### PR DESCRIPTION
In further testing I determined that the Sign In with Apple process requires Android 4.4 (API 19) or higher, when Android [switched to the chromium engine](https://developer.android.com/guide/webapps/migrating). In fact, you can't even access your [Apple ID](https://appleid.apple.com/) page in the browser pre 4.4. So to keep consistent with the Apple side of this module, I added an `isSupported` check to `appleAuthAndroid` that returns true for API 19+. The library still builds on API 16.

I also excluded `okhttp` from `flipper-network-plugin` in the example app — [a change](https://github.com/facebook/react-native/pull/29260) that is making its way into the main repo.