### PR TITLE
fix(ios): depend on React-Core directly, not React

### DIFF
--- a/RNAppleAuthentication.podspec
+++ b/RNAppleAuthentication.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "9.0"
   s.source_files        = 'ios/**/*.{h,m}'
-  s.dependency          'React'
+  s.dependency          'React-Core'
   s.static_framework    = true
 end


### PR DESCRIPTION
This is apparently needed for Xcode 12 compatibility

Reference: https://github.com/facebook/react-native/issues/29633