### PR TITLE
Fix API30 compilation error

### DIFF
--- a/android/src/main/java/com/RNAppleAuthentication/webview/SignInWebViewDialogFragment.kt
+++ b/android/src/main/java/com/RNAppleAuthentication/webview/SignInWebViewDialogFragment.kt
@@ -50,7 +50,7 @@ internal class SignInWebViewDialogFragment : DialogFragment() {
   ): View? {
     super.onCreateView(inflater, container, savedInstanceState)
 
-    val webView = WebView(context).apply {
+    val webView = WebView(context!!).apply {
       settings.apply {
         javaScriptEnabled = true
         javaScriptCanOpenWindowsAutomatically = true


### PR DESCRIPTION
This change fixes a compilation error when targeting API30 by treating the webview dialog context as non-null to satisfy the type system. Since the context is accessed inside the fragment's `onCreateView` callback, it should always be non-null anyway.