### PR TITLE
"Implement the logout process" section details updated with new usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ function App() {
 
 #### 4. Implement the logout process
 
-There is an operation `AppleAuthRequestOperation.LOGOUT`, however it does not work as expected and is not even being used by Apple in their example code. See [this issue for more information](https://github.com/invertase/react-native-apple-authentication/issues/10#issuecomment-611532131)
+There is an operation `appleAuth.Operation.LOGOUT`, however it does not work as expected and is not even being used by Apple in their example code. See [this issue for more information](https://github.com/invertase/react-native-apple-authentication/issues/10#issuecomment-611532131)
 
-So it is recommended when logging out to just clear all data you have from a user, collected during `AppleAuthRequestOperation.LOGIN`.
+So it is recommended when logging out to just clear all data you have from a user, collected during `appleAuth.Operation.LOGIN`.
 
 ### Android
 


### PR DESCRIPTION
"Implement the logout process" section keeps the old operation constants usage from "v1.x" that is `AppleAuthRequestOperation`. I updated it with the new usage that is `appleAuth.Operation`.