### PR TITLE
Add missing appleAuthAndroid import in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Make sure to correctly configure your Apple developer account to allow for prope
 
 import React from 'react';
 import { View } from 'react-native';
-import { AppleButton } from '@invertase/react-native-apple-authentication';
+import { appleAuthAndroid, AppleButton } from '@invertase/react-native-apple-authentication';
 
 async function onAppleButtonPress() {
 }


### PR DESCRIPTION
Add missing appleAuthAndroid import in README.md

```bash
import React from 'react';
import { View } from 'react-native';
import { AppleButton } from '@invertase/react-native-apple-authentication';  //appleAuthAndroid is missing in the import

async function onAppleButtonPress() {
}

// Apple authentication requires API 19+, so we check before showing the login button
function App() {
  return (
    <View>
      {appleAuthAndroid.isSupported && (
        <AppleButton
          buttonStyle={AppleButton.Style.WHITE}
          buttonType={AppleButton.Type.SIGN_IN}
          onPress={() => onAppleButtonPress()}
        />
      )}
    </View>
  );
}```