### PR TITLE
Update MIGRATION.md

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -33,7 +33,7 @@ const onAppleButtonPress = async () => {
 
 ### 2.x
 ```js
-import { appleAuth } from '@invertase/react-native-apple-authentication';
+import { appleAuth, AppleButton } from '@invertase/react-native-apple-authentication';
 
 const onAppleButtonPress = async () => {
   const appleAuthRequestResponse = await appleAuth.performRequest({


### PR DESCRIPTION
Add unused `AppleButton` import to match 1:1 with the v1 code sample.

Not that big of a deal, but I thought it would make it crystal clear how to import `<AppleButton />` with the new structure.