### PR TITLE
Change React Core dependency for Xcode 12

### DIFF
--- a/RNAppleAuthentication.podspec
+++ b/RNAppleAuthentication.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "9.0"
   s.source_files        = 'ios/**/*.{h,m}'
-  s.dependency          'React-Core'
+  s.dependency          'React/Core'
   s.static_framework    = true
 end


### PR DESCRIPTION
I'm getting the following error when installing the Pod:
```
[!] Unable to find a specification for `React-Core` depended upon by `RNAppleAuthentication`

You have either:
 * mistyped the name or version.
 * not added the source repo that hosts the Podspec to your Podfile.

error Command failed with exit code 1.
```

This change is based on: https://github.com/facebook/react-native/issues/30018#issuecomment-716041423