### PR TITLE
Update Error handling documentation for v2

### DIFF
--- a/docs/FIREBASE.md
+++ b/docs/FIREBASE.md
@@ -26,7 +26,7 @@ import { appleAuth, AppleButton } from '@invertase/react-native-apple-authentica
 
 /**
  * Note the sign in request can error, e.g. if the user cancels the sign-in.
- * Use `AppleAuthError` to determine the type of error, e.g. `error.code === AppleAuthError.CANCELED`
+ * Use `appleAuth.Error` to determine the type of error, e.g. `error.code === appleAuth.Error.CANCELED`
  */
 async function onAppleButtonPress() {
   // 1). start a apple sign-in request

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -15,6 +15,7 @@ import appleAuth, {
   AppleAuthRequestOperation,
   AppleAuthRequestScope,
   AppleAuthCredentialState,
+  AppleAuthError,
 } from '@invertase/react-native-apple-authentication';
 
 const onAppleButtonPress = async () => {
@@ -28,6 +29,13 @@ const onAppleButtonPress = async () => {
   if (credentialState === AppleAuthCredentialState.AUTHORIZED) {
     // user is authenticated
   }
+  
+  // catch signIn errors
+  ...
+  catch (error) {
+    if (error.code === AppleAuthError.CANCELED) // do something
+  }
+  ...
 }
 ```
 
@@ -46,5 +54,12 @@ const onAppleButtonPress = async () => {
   if (credentialState === appleAuth.State.AUTHORIZED) {
     // user is authenticated
   }
+  
+  // catch signIn errors
+  ...
+  catch (error) {
+    if (error.code === appleAuth.Error.CANCELED) // do something
+  }
+  ...
 }
 ```


### PR DESCRIPTION
While migrating to v2, I didn't see any of the docs mention migrating from `AppleAuthError` to `appleAuth.Error`. This PR attempts to rectify that for anybody else who runs across this in the future.