### PR TITLE
update README with info on parsing identity token

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,20 @@ export default MyAppleSigninButton;
     <key>CFBundleAllowMixedLocalizations</key>
     <string>true</string>
     ```
+3. How do I get the email after the first login?
+    - You can get the email address by parsing the JWT token that's returned from any authentication, like so:
+    ```js
+    import { appleAuth } from '@invertase/react-native-apple-authentication';
+    import jwt_decode from 'jwt-decode';
 
+    const appleAuthRequestResponse = await appleAuth.performRequest({
+      requestedOperation: appleAuth.Operation.LOGIN,
+      requestedScopes: [appleAuth.Scope.EMAIL, appleAuth.Scope.FULL_NAME]
+    });
+    // other fields are available, but full name is not
+    const { email, email_verified, is_private_email, sub } = jwt_decode(appleAuthRequestResponse.identityToken)
+    ```
+  
 ## Troubleshooting
 
 ```


### PR DESCRIPTION
I was able to implement @kidmysoul 's JWT parser reference from [this issue comment](https://github.com/invertase/react-native-apple-authentication/issues/160#issuecomment-735342187) to get the email on subsequent login attempts, so this is a small block of code to help others who might want to do the same.