### PR TITLE
fix(android): use function vs arrow for babel compat in AppleButton export

### DIFF
--- a/lib/AppleButton.android.js
+++ b/lib/AppleButton.android.js
@@ -7,7 +7,7 @@ import { ButtonTexts, ButtonTypes, ButtonVariants } from './AppleButton.shared';
  * Pure Javascript Apple Sign In button for Android.
  * Cross-compatible with native iOS version.
  */
-export default AppleButton = (props) => {
+export default function AppleButton(props) {
   const {
     style,
     textStyle,


### PR DESCRIPTION
Per discussions on [ReferenceError: ReferenceError: Can't find variable: AppleButton #150 ](https://github.com/invertase/react-native-apple-authentication/issues/150) it seems that use of the arrow function is problematic based on configurations with babel, potentially among other factors.

Changing this from using an arrow function fixes the issue and seems to be a stable fix.