### PR TITLE
fix: Updates to recommended way of importing context

### DIFF
--- a/android/src/main/java/com/RNAppleAuthentication/webview/SignInWebViewDialogFragment.kt
+++ b/android/src/main/java/com/RNAppleAuthentication/webview/SignInWebViewDialogFragment.kt
@@ -50,7 +50,7 @@ internal class SignInWebViewDialogFragment : DialogFragment() {
   ): View? {
     super.onCreateView(inflater, container, savedInstanceState)
 
-    val webView = WebView(context!!).apply {
+    val webView = WebView(requireContext()).apply {
       settings.apply {
         javaScriptEnabled = true
         javaScriptCanOpenWindowsAutomatically = true


### PR DESCRIPTION
related to: #178
@mikehardy Newest version of Android Gradle build linter are suggesting the change from `context!!` to `requireContext()`. This simple change fixes the lint errors. It's also recommended as your found out[ in this post](https://bentrengrove.com/blog/2020/6/15/requirecontext-or-context)