### PR TITLE
chore: remove buildToolsVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,6 @@ def getExtOrIntegerDefault(name) {
 
 android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
-  buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,6 +1,5 @@
 AppleAuth_kotlinVersion=1.4.32
 AppleAuth_compileSdkVersion=30
-AppleAuth_buildToolsVersion=30.0.2
 AppleAuth_minSdkVersion=16
 AppleAuth_targetSdkVersion=30
 AppleAuth_coreVersion=1.3.0

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -2,7 +2,6 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "30.0.2"
         minSdkVersion = 21
         compileSdkVersion = 30
         targetSdkVersion = 30


### PR DESCRIPTION
Since Android Gradle Plugin 3.1 (2018), it's no longer required to specify buildToolsVersion for Android.