### PR TITLE
fix(android): declare namespace / buildconfig options for gradle plugin 8+ compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,13 @@ def getExtOrIntegerDefault(name) {
 
 android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
+
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+      namespace "com.RNAppleAuthentication"
+      buildFeatures.buildConfig true
+  }
+
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')


### PR DESCRIPTION
Change is required as per announce in community: https://github.com/react-native-community/discussions-and-proposals/issues/671

Fixes #328