### PR TITLE
fix: Reorder requested scopes to place FULL_NAME first

### DIFF
--- a/docs/Auth0.md
+++ b/docs/Auth0.md
@@ -29,7 +29,7 @@ export default async function AppleAuthentication() {
         const appleAuthRequestResponse = await appleAuth.performRequest({
             nonceEnabled: false,
             requestedOperation: appleAuth.Operation.LOGIN,
-            requestedScopes: [appleAuth.Scope.EMAIL, appleAuth.Scope.FULL_NAME]
+            requestedScopes: [appleAuth.Scope.FULL_NAME, appleAuth.Scope.EMAIL]
         });
 
         const credentialState = await appleAuth.getCredentialStateForUser(


### PR DESCRIPTION
Refer to FAQ where order of scopes matters. https://github.com/invertase/react-native-apple-authentication#faqs