### PR TITLE
feat: support for VisionOS

### DIFF
--- a/RNAppleAuthentication.podspec
+++ b/RNAppleAuthentication.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.authors             = "Invertase Limited"
   s.source              = { :git => "https://github.com/invertase/react-native-apple-authentication.git", :tag => "v#{s.version}" }
   s.social_media_url    = 'http://twitter.com/invertaseio'
-  s.platforms           = { :ios => "9.0", :osx => "10.15" }
+  s.platforms           = { :ios => "9.0", :osx => "10.15", :visionos => "1.0" }
   s.source_files        = 'ios/**/*.{h,m}'
   s.dependency          'React-Core'
   s.static_framework    = true

--- a/ios/RNAppleAuthentication/RNAppleAuthASAuthorizationDelegates.m
+++ b/ios/RNAppleAuthentication/RNAppleAuthASAuthorizationDelegates.m
@@ -16,6 +16,8 @@
  */
 
 #import "RNAppleAuthASAuthorizationDelegates.h"
+#import <UIKit/UIKit.h>
+#import <AuthenticationServices/AuthenticationServices.h>
 
 
 @implementation RNAppleAuthASAuthorizationDelegates
@@ -34,7 +36,21 @@
 #if TARGET_OS_OSX
     return [[NSApplication sharedApplication] keyWindow];
 #else
-    return [[UIApplication sharedApplication] keyWindow];
+    #if TARGET_OS_VISION
+        // visionOS
+        UIWindow *window = nil;
+        NSSet<UIScene *> *connectedScenes = [UIApplication sharedApplication].connectedScenes;
+        for (UIScene *scene in connectedScenes) {
+            if (scene.activationState == UISceneActivationStateForegroundActive && [scene isKindOfClass:[UIWindowScene class]]) {
+                UIWindowScene *windowScene = (UIWindowScene *)scene;
+                window = windowScene.windows.firstObject;
+                break;
+            }
+        }
+        return window;
+    #else
+        return [[UIApplication sharedApplication] keyWindow];
+    #endif
 #endif
 }
 


### PR DESCRIPTION
I have been doing some work with this repo https://github.com/callstack/react-native-visionos

And wanted to contribute sharing what made it work for me following the instructions in [this post](https://www.oskarkwasniewski.dev/blog/bringing-react-native-libraries-to-apple-vision-pro#migrating-libraries)

This allows to run appleAuth methods for react-native-visionos

Fixes #350