### PR TITLE
fix(android): pass the specified scope when creating configuration

### DIFF
--- a/android/src/main/java/com/RNAppleAuthentication/AppleAuthenticationAndroidModule.java
+++ b/android/src/main/java/com/RNAppleAuthentication/AppleAuthenticationAndroidModule.java
@@ -150,7 +150,7 @@ public class AppleAuthenticationAndroidModule extends ReactContextBaseJavaModule
             .clientId(clientId)
             .redirectUri(redirectUri)
             .responseType(SignInWithAppleConfiguration.ResponseType.ALL)
-            .scope(SignInWithAppleConfiguration.Scope.ALL)
+            .scope(scope)
             .state(state)
             .rawNonce(rawNonce)
             .nonce(nonce)


### PR DESCRIPTION
Fixes #362 (except for `responseType`, which is left out as explained [here](https://github.com/invertase/react-native-apple-authentication/issues/362#issuecomment-2776387504))