### PR TITLE
fix: do not include yarn-related files in released bundle

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -53,6 +53,10 @@ android/gradlew.bat
 android/gradle/
 
 .idea
+yarn/
+.yarn
+.yarnrc.yml
+.release-it.json
 coverage
 yarn.lock
 e2e/
@@ -61,10 +65,12 @@ e2e/
 .nyc_output
 android/.settings
 *.coverage.json
+*.tgz
 .circleci
 .eslintignore
 type-test.ts
 example
+example-other
 docs
 .editorconfig
 .eslintrc


### PR DESCRIPTION
# Why

While browsing through React Native Directory using Bundle Size sort I have spotted that `@invertase/react-native-apple-authentication` package have unusual large bundle (106 MB).

# How

Explore the current bundle on npm to find the root cause:
* https://www.npmjs.com/package/@invertase/react-native-apple-authentication?activeTab=code

It ended up being a `.yarn` with publisher local cache and yarn bin file, which is a part of the repository. 

To fix that problem, and prevent similar accidents to happen on publish, I have modified the `.npmignore` file to exclude all Yarn-related files, the second example app (`example-other`), ReleaseIt config file and all archives created by running `npm pack` locally (`*.tgz`).

# Currently published package on npm (`latest`)

```
unpacked size: 106 MB
total files: 893
```

# `npm pack` before changes (no additional local files)

```
npm notice filename: invertase-react-native-apple-authentication-2.5.0.tgz
npm notice package size: 2.2 MB
npm notice unpacked size: 6.3 MB
npm notice total files: 68
```


# `npm pack` after changes

```
npm notice filename: invertase-react-native-apple-authentication-2.5.0.tgz
npm notice package size: 33.9 kB
npm notice unpacked size: 131.2 kB
npm notice total files: 39
```