### PR TITLE
fix: preserve caller-owned Apple authentication request options

### DIFF
--- a/lib/AppleAuthModule.js
+++ b/lib/AppleAuthModule.js
@@ -103,6 +103,8 @@ export default class AppleAuthModule {
   ) {
     throwIfNotSupported(this.isSupported);
 
+    requestOptions = { ...requestOptions };
+
     if (!Object.hasOwnProperty.call(requestOptions, ['nonceEnabled'])) {
       requestOptions.nonceEnabled = true;
     } else if (typeof requestOptions.nonceEnabled !== 'boolean') {


### PR DESCRIPTION
# Fix: caller-owned request options are no longer mutated

`performRequest(Object.freeze({}))` currently throws before reaching native code. A normal call also adds defaults to the caller's object. Copy the options before applying the existing defaults and validation.

## Compatibility

No method signature or native payload change. The intentional observable change is that callers no longer receive default fields as an undocumented mutation of their options object. Frozen option objects now work.

## Reproduction

24 inline cases cover defaults, explicit options, frozen inputs, validation, credential lookup and event removal. The 10 input-preservation cases fail on baseline and all pass after the fix.

## Verification

- Upstream ESLint and existing TypeScript usage checks pass.
- Focused inline reproductions compare unchanged `5f7a8d7` with the fix; no test/spec files were changed.
- React Doctor reports 100/100 on the changed JavaScript scope.
- Consumer verification now passes on React Native 0.87.1: both Android Debug flavors, both iOS Simulator Debug schemes (unsigned), all four production-mode Metro bundles, immutable Yarn install and app lint. All seven changed installed source files match the verified fork.
- No real Apple sign-in, account changes, physical-device authentication, macOS/visionOS runtime checks or signed release archives were performed.
