### PR TITLE
fix(android): preserve request configuration and honor code-only responses

### DIFF
--- a/android/src/main/java/com/RNAppleAuthentication/AppleAuthenticationAndroidModule.java
+++ b/android/src/main/java/com/RNAppleAuthentication/AppleAuthenticationAndroidModule.java
@@ -152,7 +152,9 @@ public class AppleAuthenticationAndroidModule extends ReactContextBaseJavaModule
         this.configuration = new SignInWithAppleConfiguration.Builder()
             .clientId(clientId)
             .redirectUri(redirectUri)
-            .responseType(SignInWithAppleConfiguration.ResponseType.ALL)
+            // Apple requires code; preserve the legacy ID_TOKEN behavior.
+            .responseType(responseType == SignInWithAppleConfiguration.ResponseType.ID_TOKEN
+                ? SignInWithAppleConfiguration.ResponseType.ALL : responseType)
             .scope(scope)
             .state(state)
             .rawNonce(rawNonce)
@@ -163,7 +165,8 @@ public class AppleAuthenticationAndroidModule extends ReactContextBaseJavaModule
 
     @ReactMethod
     public void signIn(final Promise promise) {
-        if (this.configuration == null) {
+        final SignInWithAppleConfiguration requestConfiguration = this.configuration;
+        if (requestConfiguration == null) {
             promise.reject(E_NOT_CONFIGURED_ERROR);
             return;
         }
@@ -182,7 +185,7 @@ public class AppleAuthenticationAndroidModule extends ReactContextBaseJavaModule
                 response.putString("id_token", id_token);
                 response.putString("state", state);
 
-                String rawNonce = configuration.getRawNonce();
+                String rawNonce = requestConfiguration.getRawNonce();
                 if (!rawNonce.isEmpty()) {
                   response.putString("nonce", rawNonce);
                 }
@@ -229,7 +232,7 @@ public class AppleAuthenticationAndroidModule extends ReactContextBaseJavaModule
         SignInWithAppleService service = new SignInWithAppleService(
                 fragmentManager,
                 fragmentTag,
-                configuration,
+                requestConfiguration,
                 callback
         );
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -504,6 +504,7 @@ export type AndroidError = {
 export declare enum AndroidResponseType {
   ALL = "ALL",
   CODE = "CODE",
+  /** @deprecated Apple requires a code response. Kept as an alias for ALL. */
   ID_TOKEN = "ID_TOKEN",
 }
 
@@ -521,7 +522,7 @@ export interface AndroidConfig {
    * IP address or localhost. */
   redirectUri: string;
 
-  /** The type of response requested.  */
+  /** The type of response requested. ID_TOKEN is a legacy alias for ALL. */
   responseType?: AndroidResponseType;
 
   /** The amount of user information requested from Apple. */
@@ -632,7 +633,8 @@ export interface AppleAuthAndroid {
   Scope: typeof AndroidScope;
 
   /**
-   * The type of response requested. Valid values are `code` and `id_token`. You can request one or both.
+   * The type of response requested: CODE or ALL (code and id_token).
+   * The legacy ID_TOKEN value behaves as ALL because Apple requires code.
    */
   ResponseType: typeof AndroidResponseType;
 }


### PR DESCRIPTION
# Fixes: isolate in-flight sign-ins and honor CODE responses

- Capture the configuration for each sign-in, including its nonce. Calling `configure` while sign-in is pending must not return the replacement configuration's nonce with the original credential.
- Honor `ResponseType.CODE` instead of always requesting code and ID token.
- Preserve `ID_TOKEN` as the existing ALL behavior and document/deprecate that legacy value. Apple requires code; this avoids introducing an unsupported ID-token-only request. This follows the unresolved response-type discussion in #362/#363.

## Compatibility / observable changes

CODE now produces a code-only request as documented. Applications that selected CODE but relied on the previously accidental ID token should select ALL explicitly. Defaults, ALL and legacy ID_TOKEN retain their request behavior. No exports or enum values are removed.

## Reproduction

Compiled the actual Java module with isolated Android/React bridge/service stubs. Six cases cover three response types and enabled/disabled nonces, replacing configuration before callback. Baseline has two response-type mismatches and six nonce mismatches; the fix has zero of either. This is not a live OAuth flow.

## Verification

- Upstream ESLint and existing TypeScript usage checks pass.
- Focused inline reproductions compare unchanged `5f7a8d7` with the fix; no test/spec files were changed.
- React Doctor reports 100/100 on the changed JavaScript scope.
- Consumer verification now passes on React Native 0.87.1: both Android Debug flavors, both iOS Simulator Debug schemes (unsigned), all four production-mode Metro bundles, immutable Yarn install and app lint. All seven changed installed source files match the verified fork.
- No real Apple sign-in, account changes, physical-device authentication, macOS/visionOS runtime checks or signed release archives were performed.
