### PR TITLE
fix: export runtime values for the declared public enums

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,7 @@
 import version from './version';
 import { NativeModules } from 'react-native';
 import AppleAuthModule from './AppleAuthModule';
+import { ButtonTypes, ButtonVariants } from './AppleButton.shared';
 const { RNAppleAuthModule, RNAppleAuthModuleAndroid } = NativeModules;
 
 export { default as AppleButton } from './AppleButton';
@@ -27,6 +28,26 @@ export { default as AppleButton } from './AppleButton';
  */
 export const appleAuth = new AppleAuthModule(RNAppleAuthModule, version);
 export default appleAuth;
+
+export const AppleButtonType = ButtonTypes;
+export const AppleButtonStyle = ButtonVariants;
+export const AppleError = appleAuth.Error;
+export const AppleRequestOperation = appleAuth.Operation;
+export const AppleRequestScope = appleAuth.Scope;
+export const AppleRealUserStatus = appleAuth.UserStatus;
+export const AppleCredentialState = appleAuth.State;
+
+export const AndroidResponseType = {
+  ALL: 'ALL',
+  CODE: 'CODE',
+  ID_TOKEN: 'ID_TOKEN',
+};
+
+export const AndroidScope = {
+  ALL: 'ALL',
+  EMAIL: 'EMAIL',
+  NAME: 'NAME',
+};
 
 /**
  * Android


### PR DESCRIPTION
# Fix: provide the runtime enum exports already declared by TypeScript

The declarations export nine enums, but `lib/index.js` exports none of their runtime values. Imports type-check and then evaluate to undefined.

Export AppleButtonType, AppleButtonStyle, AppleError, AppleRequestOperation, AppleRequestScope, AppleRealUserStatus, AppleCredentialState, AndroidResponseType and AndroidScope. Reuse the existing Apple module/button constants; make Android enum values available even when its native module is absent.

## Compatibility

Additive exports only. Existing default/module constants and native methods are unchanged. Declared enum names and values are preserved; no new dependency is required.

## Reproduction

Evaluate the actual entrypoint and its local modules with a mocked React Native bridge, both with and without native modules. Baseline is missing all nine exports; the fix provides all nine with checked values. Existing TypeScript usage checks also pass.

## Verification

- Upstream ESLint and existing TypeScript usage checks pass.
- Focused inline reproductions compare unchanged `5f7a8d7` with the fix; no test/spec files were changed.
- React Doctor reports 100/100 on the changed JavaScript scope.
- Consumer verification now passes on React Native 0.87.1: both Android Debug flavors, both iOS Simulator Debug schemes (unsigned), all four production-mode Metro bundles, immutable Yarn install and app lint. All seven changed installed source files match the verified fork.
- No real Apple sign-in, account changes, physical-device authentication, macOS/visionOS runtime checks or signed release archives were performed.
