### PR TITLE
fix(security): [LOW] limit PR title token privileges

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -9,8 +9,10 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     env:
-      GITHUB_TOKEN: ${{ secrets.MIKE_HARDY_RNAA_RELEASE_GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: amannn/action-semantic-pull-request@v6.1.1
         with:


### PR DESCRIPTION
## Summary

- Replaces the reusable release PAT in the PR-title workflow with the per-run `GITHUB_TOKEN`.
- Restricts that token to `pull-requests: read`, the permission required by the configured validator.
- Leaves PR-title and single-commit validation behavior unchanged.

## Security impact

The `pull_request_target` workflow is fork-triggerable and currently gives a third-party validation action a long-lived release token even though its enabled code paths only read pull-request and commit metadata. No current exfiltration path was found, so this is marked **LOW** urgency; the change reduces the blast radius of any future action or workflow compromise.

This PR intentionally addresses only credential scope. Action-reference pinning is submitted separately so each security hardening change can be reviewed independently.

## Verification

- Reviewed `amannn/action-semantic-pull-request` v6.1.1 for the configured options.
- Confirmed `pulls.get` and `pulls.listCommits` are covered by `pull-requests: read`.
- Parsed the changed workflow as YAML.
- Ran `git diff --check`.
- Completed an independent patch review.

The repository does not include an automated test suite for this workflow behavior.
